### PR TITLE
Add simple Spine runtime

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,8 @@ func main() {
 	}
 	fmt.Println(spineData.Skeleton.Hash)
 
+	spineData.SetAnimation("idle")
+
 	g, err := game.NewGame(game.WithScreenSize(800, 600),
 		game.WithTitle("toy"),
 		game.WithSpine(spineData),

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -20,6 +20,9 @@ func (g *Game) Run() error {
 }
 
 func (g *Game) Update() error {
+	if g.spine != nil {
+		g.spine.Update(1.0 / 60.0)
+	}
 	return nil
 }
 

--- a/internal/spine/animation.go
+++ b/internal/spine/animation.go
@@ -1,0 +1,68 @@
+package spine
+
+// Keyframe represents a single keyframe for translation or rotation.
+type Keyframe struct {
+	Time  float64 `json:"time,omitempty"`
+	X     float64 `json:"x,omitempty"`
+	Y     float64 `json:"y,omitempty"`
+	Value float64 `json:"value,omitempty"`
+}
+
+// BoneAnimation holds keyframes for a bone.
+type BoneAnimation struct {
+	Translate []Keyframe `json:"translate,omitempty"`
+	Rotate    []Keyframe `json:"rotate,omitempty"`
+}
+
+// Animation represents a single animation consisting of multiple bone animations.
+type Animation struct {
+	Bones map[string]BoneAnimation `json:"bones"`
+}
+
+// BoneTransform stores runtime transform values for a bone.
+type BoneTransform struct {
+	X        float64
+	Y        float64
+	Rotation float64
+}
+
+// sampleVec2 interpolates translation keyframes to get position at time t.
+func sampleVec2(frames []Keyframe, t float64) (float64, float64) {
+	if len(frames) == 0 {
+		return 0, 0
+	}
+	if t <= frames[0].Time {
+		return frames[0].X, frames[0].Y
+	}
+	for i := 0; i < len(frames)-1; i++ {
+		f0 := frames[i]
+		f1 := frames[i+1]
+		if t < f1.Time {
+			r := (t - f0.Time) / (f1.Time - f0.Time)
+			x := f0.X + (f1.X-f0.X)*r
+			y := f0.Y + (f1.Y-f0.Y)*r
+			return x, y
+		}
+	}
+	last := frames[len(frames)-1]
+	return last.X, last.Y
+}
+
+// sampleValue interpolates rotation keyframes to get value at time t.
+func sampleValue(frames []Keyframe, t float64) float64 {
+	if len(frames) == 0 {
+		return 0
+	}
+	if t <= frames[0].Time {
+		return frames[0].Value
+	}
+	for i := 0; i < len(frames)-1; i++ {
+		f0 := frames[i]
+		f1 := frames[i+1]
+		if t < f1.Time {
+			r := (t - f0.Time) / (f1.Time - f0.Time)
+			return f0.Value + (f1.Value-f0.Value)*r
+		}
+	}
+	return frames[len(frames)-1].Value
+}


### PR DESCRIPTION
## Summary
- implement a toy Spine runtime in Go
- support loading animations and advancing them
- integrate runtime update into the game loop

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68416bfc1c588329965f65b62e4d61a1